### PR TITLE
Root Namespace specified incorrectly.  Fixes #4

### DIFF
--- a/AdomdClientNetCore/AdomdClientNetCore.csproj
+++ b/AdomdClientNetCore/AdomdClientNetCore.csproj
@@ -9,6 +9,7 @@
     <Description>Unofficial AdomdClient ported to .NET Core. WARNING: may not support your scenario, use at your own risk! WARNING: does not support WindowsPrincipal.</Description>
     <PackageTags>Adomd AdomdClient AdomdClientNetCore AdomdClientCore Microsoft.AnalysisServices.AdomdClient</PackageTags>
     <PackageProjectUrl>https://github.com/bdebaere/Unofficial.Microsoft.AnalysisServices.AdomdClientNetCore</PackageProjectUrl>
+    <RootNamespace />
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Root namespace default is set to "AdomdClientNetCore" when not specified in the solution file.  This causes complied resources to be named "AdomdClientNetCore.Microsoft.AnalysisServices.AdomdClient.SR.resources" instead of "Microsoft.AnalysisServices.AdomdClient.SR.resources".  When a string from these resource files is accessed, a MissingManifestException is generated.  This fix removes the default namespace, allowing the resource files to be compiled properly.